### PR TITLE
Less source map option

### DIFF
--- a/doc/lesscss.txt
+++ b/doc/lesscss.txt
@@ -82,6 +82,17 @@ set in your `.vimrc`, such as |lesscss_on|, |lesscss_cmd| and
 Default: 1
 If enabled, |:Lesscss| runs on each LESS file save.
 
+                                                  *'lesscss_enable_sourcemap'*
+Default: 0
+Enable source map for output. The map file will be placed in the same
+directory where the generated stylesheet, e.g. your can refine its location
+via |'lesscss_save_to'| option.
+
+Any additional source map options can be passed into the less compiler
+directly. >
+    let g:lesscss_cmd = '$(which lessc) --source-map-rootpath=/'
+<
+
 ------------------------------------------------------------------------------
 2.2 Commands                                                *lesscss-commands*
 

--- a/plugin/lesscss.vim
+++ b/plugin/lesscss.vim
@@ -25,6 +25,9 @@ call lesscss#default('g:lesscss_on', 1)
 " default key binding
 call lesscss#default('g:lesscss_toggle_key', '<Leader>l')
 
+" enable source map for output css
+call lesscss#default('g:lesscss_enable_sourcemap', 0)
+
 " registered commands
 call lesscss#default('g:lesscss_commands', {
       \ 'on': {'lesscss_on': 1},
@@ -52,6 +55,10 @@ function! s:lesscss_pipeline()
   let lessc = lesscss#get_option('lesscss_cmd')
   let save_to = lesscss#get_option('lesscss_save_to')
   let save_to = expand('%:p:h').'/'.save_to
+
+  if lesscss#get_option('lesscss_enable_sourcemap')
+    let lessc .= ' --source-map="'.save_to.'%:t:r.css.map"'
+  endif
 
   " prevent writing to remote dirs like ftp://*
   if save_to !~# '\v^\w+\:\/'


### PR DESCRIPTION
`lessc` require file name for `--source-map` option since this script used the > character to output the css file. Full command look like this:

```
lessc style.less > ../css/style.css --source-map=../css/style.css.map
```

There are some workaround to add the option directory to `lessc_cmd` but it will be simpler if this plugin have an option to toggle on / off this flag.
